### PR TITLE
cld.gov.au now supports nginx buildpack, switching

### DIFF
--- a/.deploy/stag-manifest.yml
+++ b/.deploy/stag-manifest.yml
@@ -1,6 +1,6 @@
 applications:
     - name: new-ausgov
-      buildpack: staticfile_buildpack
+      buildpack: nginx_buildpack
       memory: 64M
       instances: 1
       path: ../public


### PR DESCRIPTION
### What this PR does


### Checklist
- [ ] I've updated CHANGES.md with what I changed.